### PR TITLE
Now we reset `engineTypeChangeTimer` AFTER setting engine type, that …

### DIFF
--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -570,10 +570,10 @@ static void handleCommandX14(uint16_t index) {
 extern bool rebootForPresetPending;
 
 static void applyPreset(int index) {
+  setEngineType(index);
 #if EFI_TUNER_STUDIO
 	onApplyPreset();
 #endif // EFI_TUNER_STUDIO
-  setEngineType(index);
 }
 
 PUBLIC_API_WEAK void boardTsAction(uint16_t index) { }


### PR DESCRIPTION
…is time-consuming operation (closes #8032)